### PR TITLE
fix: Remove currenTime from /about

### DIFF
--- a/src/controllers/handlers/about-handler.ts
+++ b/src/controllers/handlers/about-handler.ts
@@ -109,11 +109,9 @@ export async function aboutHandler(
   } else {
     const clusterStatus = await serviceDiscovery.getClusterStatus()
     if (clusterStatus.archipelago) {
-      result.comms = {
-        ...result.comms,
-        healthy: true,
-        ...clusterStatus.archipelago
-      }
+      result.comms.healthy = true
+      result.comms.protocol = 'v3'
+      result.comms.commitHash = clusterStatus.archipelago.commitHash
     } else {
       result.comms.healthy = false
     }


### PR DESCRIPTION
When getting /about of a catalyst with comms v3, then it's showing the field `currenTime`, this PR removes it.