### PR TITLE
fix: catalyst version of lambdas and content

### DIFF
--- a/src/ports/status.ts
+++ b/src/ports/status.ts
@@ -72,7 +72,7 @@ export async function createStatusComponent(
 
       lastLambdasStatus = {
         time: Date.now(),
-        version: data.version,
+        version: data.catalystVersion,
         commitHash: data.commitHash
       }
 
@@ -95,7 +95,7 @@ export async function createStatusComponent(
 
       lastContentStatus = {
         time: Date.now(),
-        version: data.version,
+        version: data.catalystVersion,
         commitHash: data.commitHash
       }
 


### PR DESCRIPTION
It was reading `version` field and it should use `catalystVersion`