### PR TITLE
chore: ensure port closed callback is executed once

### DIFF
--- a/src/controllers/rpc/initialize-rpc-server-handler.ts
+++ b/src/controllers/rpc/initialize-rpc-server-handler.ts
@@ -106,7 +106,12 @@ async function registerAuthenticatedConnectionModules(
   await onPeerConnected(context)
   // Remove the port from the rpcSessions if present.
   // TODO: write a test for this
+  let portClosed = false
   port.on('close', async () => {
+    if (portClosed) {
+      return
+    }
+    portClosed = true
     if (context.components.rpcSessions.sessions.get(address)?.port === port) {
       context.components.rpcSessions.sessions.delete(address)
     }


### PR DESCRIPTION
I don't actually know if this is happening, but it's the only thing I can think of that's causing the wrong metrics