### PR TITLE
feat: add tag version as environment variable and return it at /about

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -11,6 +11,7 @@ jobs:
     with:
       service-name: explorer-bff
       docker-tag: latest ${{ github.event.release.tag_name }}
+      build-args: CURRENT_VERSION=${{ github.event.release.tag_name }}
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ ENV NODE_ENV production
 ARG COMMIT_HASH=local
 ENV COMMIT_HASH=${COMMIT_HASH:-local}
 
+ARG CURRENT_VERSION=Unknown
+ENV CURRENT_VERSION=${CURRENT_VERSION:-Unknown}
+
 WORKDIR /app
 COPY --from=builderenv /app /app
 COPY --from=builderenv /tini /tini

--- a/src/controllers/handlers/about-handler.ts
+++ b/src/controllers/handlers/about-handler.ts
@@ -67,6 +67,7 @@ export async function aboutHandler(
     comms,
     bff: {
       healthy: true,
+      version: await config.getString('CURRENT_VERSION'),
       commitHash: await config.getString('COMMIT_HASH'),
       userCount,
       protocolVersion: protobufPackage.replace('_', '.').replace(/^v/, ''),


### PR DESCRIPTION
Add semver as environment variable to be returned at /about endpoint. This version will be used to enhance the realm-picking algorithm by redirecting the users to the most updated catalyst stack if the invariant is set to do so.